### PR TITLE
Fix issue of char `+`

### DIFF
--- a/carbon-now-sh.el
+++ b/carbon-now-sh.el
@@ -55,9 +55,8 @@
   "Open current region in carbon.now.sh."
   (interactive)
   (browse-url
-   (url-encode-url
-    (s-replace "#" "%23"
-      (concat carbon-now-sh-baseurl "?code=" (carbon-now-sh--region))))))
+   (concat carbon-now-sh-baseurl "?code="
+           (url-hexify-string (carbon-now-sh--region)))))
 
 (provide 'carbon-now-sh)
 ;;; carbon-now-sh.el ends here


### PR DESCRIPTION
1. use `url-hexify-string` rather than `url-encode-url`.
2. encode `code` parameter only rather than whole url.