### PR TITLE
fix: When the region isn't present, open URL with no code

### DIFF
--- a/carbon-now-sh.el
+++ b/carbon-now-sh.el
@@ -51,7 +51,7 @@
                                 (beg (and (use-region-p) (region-beginning)))
                                 (end (and (use-region-p) (region-end))))
   "Return code in current region."
-  (buffer-substring-no-properties beg end))
+  (when beg (buffer-substring-no-properties beg end)))
 
 ;;;###autoload
 (defun carbon-now-sh ()


### PR DESCRIPTION
I believe this'll be a more intuitive behavior.

Either this, or showing a warning instead of a cryptic error from deep in the callstack:
```
progn: Wrong type argument: integer-or-marker-p, nil
```